### PR TITLE
Fix get for AbstractVectorFunction

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -424,16 +424,6 @@ function MathOptInterface.get{D}(m     ::MosekModel,
 end
 
 
-function MathOptInterface.get(
-    m     ::MosekModel,
-    attr  ::MathOptInterface.ConstraintDual,
-    cref  ::MathOptInterface.ConstraintReference{MathOptInterface.VectorAffineFunction{Float64},D}) where { D <: MathOptInterface.AbstractSet }
-    
-    n = blocksize(m.c_block,ref2id(cref))
-    res = Vector{Float64}(n)
-    MathOptInterface.get!(res,m,attr,cref)
-    res
-end
 function MathOptInterface.get!(
     output::Vector{Float64},
     m     ::MosekModel,
@@ -481,8 +471,8 @@ end
 
 
 
-solsize{F <: MathOptInterface.AbstractScalarFunction,D}(m::MosekModel, cref :: MathOptInterface.ConstraintReference{F,D}) = 1
-function solsize{D}(m::MosekModel, cref :: MathOptInterface.ConstraintReference{MathOptInterface.VectorOfVariables,D})
+solsize(m::MosekModel, cref :: MathOptInterface.ConstraintReference{<:MathOptInterface.AbstractScalarFunction}) = 1
+function solsize(m::MosekModel, cref :: MathOptInterface.ConstraintReference{MathOptInterface.VectorOfVariables})
     cid = ref2id(cref)
     if cid < 0
         blocksize(m.c_block,-cid)
@@ -491,12 +481,12 @@ function solsize{D}(m::MosekModel, cref :: MathOptInterface.ConstraintReference{
     end
 end
 
-function solsize{D}(m::MosekModel, cref :: MathOptInterface.ConstraintReference{MathOptInterface.VectorAffineFunction,D})
+function solsize(m::MosekModel, cref :: MathOptInterface.ConstraintReference{<:MathOptInterface.VectorAffineFunction})
     cid = ref2id(cref)
     blocksize(m.c_block,cid)
 end
 
-function MathOptInterface.get{F <: MathOptInterface.AbstractScalarFunction,D}(m::MosekModel,attr::MathOptInterface.ConstraintPrimal, cref :: MathOptInterface.ConstraintReference{F,D})
+function MathOptInterface.get{F <: MathOptInterface.AbstractVectorFunction,D}(m::MosekModel, attr::Union{MathOptInterface.ConstraintPrimal, MathOptInterface.ConstraintDual}, cref :: MathOptInterface.ConstraintReference{F,D})
     cid = ref2id(cref)
     output = Vector{Float64}(solsize(m,cref))
     MathOptInterface.get!(output,m,attr,cref)


### PR DESCRIPTION
`get` wasn't defined for `AbstractVectorFunction`, except for `ConstraintDual` with `VectorAffineFunction` while `get!` is defined for every case.
I figured the `AbstractScalarFunction` was meant to be `AbstractVectorFunction` in the code below.