### PR TITLE
Drop zero coefficients

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -383,6 +383,7 @@ function addlhsblock!(m        :: MosekModel,
     N = length(consubi)
 
     At = sparse(subj, conidxs, cofs, getnumvar(m.task), N)
+    dropzeros!(At)
     putarowlist(m.task,convert(Vector{Int32},consubi),At)
 end
 


### PR DESCRIPTION
Zeros are created in the sparse matrix if the sum of the coefficients of one variable is zero.
Mosek then throws a warning like
```
MOSEK warning 705: #75 (nearly) zero elements are specified in sparse row ''(0) of matrix 'A'.
```
`Base.dropzeros!` solves this issue.