### PR TITLE
Fixed variable name in modifyconstraint!

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -629,7 +629,7 @@ function MOI.modifyconstraint!(m::MosekModel,
     xid = ref2id(func.variable)
     j = getindexes(m.x_block,xid)[1]
 
-    putaijlist(m.task,convert(Vector{Int32},subi),fill(j,length(subi)),fund.new_coefficients)
+    putaijlist(m.task,convert(Vector{Int32},subi),fill(j,length(subi)),func.new_coefficients)
 end
 
 


### PR DESCRIPTION
This PR fixes the variable not found error when modifyconstraint!-ing a VectorAffineFunction constraint with a MultirowChange. This simply changes `fund` to `func`, after which the function works correctly.