### PR TITLE
Removed floating println statement

### DIFF
--- a/src/constraint.jl
+++ b/src/constraint.jl
@@ -355,7 +355,6 @@ function MOI.addconstraint!{D <: MOI.AbstractSet}(m :: MosekModel, xs :: MOI.Vec
     end
 
     mask = domain_type_mask(dom)
-    println("subj = $(subj), $(m.x_block)")
     if any(mask .& m.x_boundflags[subj] .> 0)
         error("Cannot multiple bound sets of the same type to a variable")
     end


### PR DESCRIPTION
This PR removes a `println` in `addconstraint!` that completely swamps all other program output for larger problem sizes.