### PR TITLE
Removed CopyResult from copy! of model

### DIFF
--- a/src/MathOptInterfaceMosek.jl
+++ b/src/MathOptInterfaceMosek.jl
@@ -423,7 +423,7 @@ function MOI.copy!(dest::MosekModel, src::MOI.ModelLike; copynames=true)
         #res.status == MOI.CopySuccess || return res
     end
 
-    return MOI.CopyResult(MOI.CopySuccess, "", idxmap)
+    return idxmap
 end
 
 


### PR DESCRIPTION
CopyResult was removed from MathOptInterface [here](https://github.com/JuliaOpt/MathOptInterface.jl/commit/3d65048738b06fc25bdb4258433cc91da066355c#diff-4fdb6b9b1724d6bf84b79b1343423d12) and replaced with thrown exceptions and returning the idxmap directly. This mirrors that change in MathOptInterfaceMosek, allowing it to work again.