### PR TITLE
Implement SolverName

### DIFF
--- a/src/MathOptInterfaceMosek.jl
+++ b/src/MathOptInterfaceMosek.jl
@@ -423,6 +423,8 @@ function MOI.empty!(model::MosekModel)
     model.feasibility   = true
 end
 
+MOI.get(::MosekModel, ::MOI.SolverName) = "Mosek"
+
 MOIU.supports_default_copy_to(::MosekModel, copy_names::Bool) = !copy_names
 function MOI.copy_to(dest::MosekModel, src::MOI.ModelLike; kws...)
     return MOIU.automatic_copy_to(dest, src; kws...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,10 @@ MOIU.@model(Model,
             (MOI.VectorOfVariables,),
             (MOI.VectorAffineFunction,))
 
+@testset "SolverName" begin
+    @test MOI.get(optimizer, MOI.SolverName()) == "Mosek"
+end
+
 @testset "Copy" begin
     # Currently does not work because get is missing for ConstraintSet
     # and ConstraintFunction, see https://github.com/JuliaOpt/MathOptInterfaceMosek.jl/issues/50


### PR DESCRIPTION
@ulfworsoe Let us know if you prefer the name to be "MOSEK" instead of "Mosek". It will be printed when a JuMP Mosel is printed, e.g.
```julia
julia> using JuMP

julia> using MathOptInterfaceMosek

julia> model = Model(with_optimizer(MosekOptimizer))
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: Automatic
CachingOptimizer state: EmptyOptimizer
Solver name: Mosek
```