### PR TITLE
Extend Mosek.Optimizer

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.7
 MathOptInterface 0.8 0.9
-Mosek 0.9.8
+Mosek 0.9.9
 Compat 1

--- a/src/MathOptInterfaceMosek.jl
+++ b/src/MathOptInterfaceMosek.jl
@@ -6,8 +6,6 @@ const MOIU = MOI.Utilities
 using Mosek
 #using Mosek.Ext
 
-export MosekOptimizer
-
 using Compat # for findall
 
 include("LinkedInts.jl")
@@ -324,7 +322,8 @@ function parse_parameters(kws)
     return be_quiet, fallback,ipars, dpars, spars
 end
 
-function MosekOptimizer(; kws...)
+export Mosek
+function Mosek.Optimizer(; kws...)
     be_quiet, fallback,ipars, dpars, spars = parse_parameters(kws)
     return MosekModel(parametrized_task(be_quiet, ipars, dpars, spars), # task
                       be_quiet,


### PR DESCRIPTION
See https://github.com/JuliaOpt/Mosek.jl/pull/171
We export the `Mosek` module so that the user only have to do `using MosekTools` and does not also need to do `using Mosek`.
So the user can simply do
```julia
using MosekTools
using JuMP
model = Model(with_optimizer(Mosek.Optimizer))
```